### PR TITLE
Handle generic ListValue field

### DIFF
--- a/viewer.go
+++ b/viewer.go
@@ -67,7 +67,7 @@ func populate(msg protoreflect.Message, populatedFields *set.Set[protoreflect.Fu
 				element := val.List().NewElement()
 				populate(element.Message(), newSeenTypes)
 				val.List().Append(element)
-			} else {
+			} else if !field.IsMap() {
 				populate(val.Message(), newSeenTypes)
 			}
 


### PR DESCRIPTION
TL;DR:

* ListValue is a supported gRPC type
* When trying to populate ListValue with an element, it creates a `struct` value
* The sub-object of `struct` is `map`
* We have no idea what to populate an empty `map` with, so we shouldn't try to